### PR TITLE
Drop time-related references.

### DIFF
--- a/Software Engineer Scala Connectivity.md
+++ b/Software Engineer Scala Connectivity.md
@@ -1,4 +1,4 @@
-[HolidayCheck](http://www.holidaycheck.de/) is deeply commited to providing the best experience in online travel for our customers. Over the past month we've been rewriting most of our backend using Scala and Finatra. Now we need help to bring our platform to the next level from a passionate
+[HolidayCheck](http://www.holidaycheck.de/) is deeply commited to providing the best experience in online travel for our customers. Now we need help to bring our platform to the next level from a passionate
 
 # (Senior) Software Engineer – Connectivity & APIs (Scala)
 

--- a/Software Engineer Scala Fullstack.md
+++ b/Software Engineer Scala Fullstack.md
@@ -1,4 +1,4 @@
-[HolidayCheck](http://www.holidaycheck.de/) is deeply commited to providing the best experience in online travel for our customers. Over the past month we've been rewriting most of our backend using Scala and Finatra. Now we need help to bring our platform to the next level from a passionate
+[HolidayCheck](http://www.holidaycheck.de/) is deeply commited to providing the best experience in online travel for our customers. Now we need help to bring our platform to the next level from a passionate
 
 # (Senior) Software Engineer – Scala / Fullstack
 

--- a/Software Engineer Search.md
+++ b/Software Engineer Search.md
@@ -1,4 +1,4 @@
-[HolidayCheck](http://www.holidaycheck.de/) is deeply committed to providing the best experience in online travel for our customers. Search is an essential part of this experience, and we're currently looking for you to support our fantastic core services engineering team to improve our search functionality and REST APIs.
+[HolidayCheck](http://www.holidaycheck.de/) is deeply committed to providing the best experience in online travel for our customers. Search is an essential part of this experience, and we're currently looking for you to support our fantastic team to improve our search functionality and REST APIs.
 
 # (Senior) Software Engineer – Search
 


### PR DESCRIPTION
References to too-concrete technologies and team names are bound to become outdated. This PR fixes already obsolete references by dropping them altogether in order to avoid becoming outdated again in the future.